### PR TITLE
Added forceDirty method to knockout.dirtyFlag.js

### DIFF
--- a/knockout.dirtyFlag.js
+++ b/knockout.dirtyFlag.js
@@ -42,6 +42,11 @@
                 result = function () {
                     var self = this;
 
+                    self.forceDirty = function ()
+                    {
+                        _isInitiallyDirty(true);
+                    };
+
                     self.isDirty = ko.computed(function () {
                         return _isInitiallyDirty() || hashFunction(_objectToTrack) !== _lastCleanState();
                     });


### PR DESCRIPTION
Allows using code to force a dirtyFlag into the dirty state after it has been initialized created.
