### PR TITLE
Fix for Issue #11

### DIFF
--- a/knockout.dirtyFlag.js
+++ b/knockout.dirtyFlag.js
@@ -35,13 +35,12 @@
             hashFunction = hashFunction || ko.toJSON;
 
             var
+                self = this,
                 _objectToTrack = objectToTrack,
                 _lastCleanState = ko.observable(hashFunction(_objectToTrack)),
                 _isInitiallyDirty = ko.observable(isInitiallyDirty),
 
                 result = function () {
-                    var self = this;
-
                     self.forceDirty = function ()
                     {
                         _isInitiallyDirty(true);
@@ -55,10 +54,9 @@
                         _lastCleanState(hashFunction(_objectToTrack));
                         _isInitiallyDirty(false);
                     };
-
                     return self;
                 };
-            
+
             return result;
         };
     })(ko);


### PR DESCRIPTION
Problem: isDirty and reset functions where added to the model. Fixed it
by moving the assignment of "self" out of the result function. So the
this-Reference of the actual dirtyFlag-Object is saved in the variable
self and when the result function is called later, the isDirty and reset
functions are added to the dirtyFlag-Object and not to the viewmodel or the window.
