### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ See this post for more details on KoLite: http://www.johnpapa.net/kolite1-1
 
 6. Renamed file knockout.asyncCommand.js to knockout.command.js as it now contains both async and sync commands.
 
-##NuGet
+## NuGet
 Also available on NuGet at https://nuget.org/packages/KoLite
 
-##Super Quick Start
+## Super Quick Start
 You can check out this fiddle to see the asyncCommand, command and activity in action. http://jsfiddle.net/hfjallemark/zEKRb/
 
 ## Quick Start


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
